### PR TITLE
Updates to get StackTraceExplorer working more efficiently on a large solution (~380 projects)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
-/.vs/StackTraceExplorer/v15/*.suo
-/StackTraceExplorer/bin
-/StackTraceExplorer/obj
-/packages
-/StackTraceExplorer/*.user
-/.vs
-/StackTraceExplorer.Tests/bin
-/StackTraceExplorer.Tests/obj
-/StackTraceExplorer.VS2019/bin
-/StackTraceExplorer.VS2019/obj
-/StackTraceExplorer.VS2022/bin
-/StackTraceExplorer.VS2022/obj
+# Build results
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+
+# User-specific files
+*.suo
+*.user
+
+# Visual Studio options directory
+.vs/

--- a/StackTraceExplorer.Shared/CustomLinkVisualLineText.cs
+++ b/StackTraceExplorer.Shared/CustomLinkVisualLineText.cs
@@ -4,9 +4,9 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.TextFormatting;
-using ICSharpCode.AvalonEdit.Rendering;
+using Community.VisualStudio.Toolkit;
 using ICSharpCode.AvalonEdit.Document;
-using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Rendering;
 using StackTraceExplorer.Helpers;
 
 namespace StackTraceExplorer
@@ -22,11 +22,13 @@ namespace StackTraceExplorer
 
         public Brush ForegroundBrush { get; set; }
 
-        public Func<string[], bool> ClickFunction { get; set; }
+        public Action<string[], StackTraceEditor> ClickFunction { get; set; }
 
         public TextDocument TextDocument { get; set; }
 
-        public TextEditor TextEditor { get; set; }
+        public StackTraceEditor TextEditor { get; set; }
+
+        OutputWindowPane OutputWindowPane { get; }
 
         /// <summary>
         /// Creates a visual line text element with the specified length.
@@ -34,8 +36,8 @@ namespace StackTraceExplorer
         /// <see cref="VisualLineElement.RelativeTextOffset"/> to find the actual text string.
         /// </summary>
         public CustomLinkVisualLineText(string[] theLink, VisualLine parentVisualLine, int length, 
-            Brush foregroundBrush, Func<string[], bool> clickFunction, bool requireControlModifierForClick,
-            TextDocument textDocument, TextEditor textEditor)
+            Brush foregroundBrush, Action<string[], StackTraceEditor> clickFunction, bool requireControlModifierForClick,
+            TextDocument textDocument, StackTraceEditor textEditor)
             : base(parentVisualLine, length)
         {
             RequireControlModifierForClick = requireControlModifierForClick;
@@ -97,7 +99,7 @@ namespace StackTraceExplorer
             {
                 e.Handled = true;
 
-                _ = ClickFunction(Link);
+                ClickFunction(Link, this.TextEditor);
                 TraceHelper.ViewModel.AddClickedLine(this);
 
                 (e.Source as TextView).Redraw();

--- a/StackTraceExplorer.Shared/Generators/FileLinkElementGenerator.cs
+++ b/StackTraceExplorer.Shared/Generators/FileLinkElementGenerator.cs
@@ -14,10 +14,10 @@ namespace StackTraceExplorer.Generators
         // To use this class:
         // textEditor.TextArea.TextView.ElementGenerators.Add(new FileLinkElementGenerator());
 
-        private readonly TextEditor _textEditor;
-        private static readonly Regex FilePathRegex = new Regex(@"((?:[A-Za-z]\:|\\|/)(?:[\\/a-zA-Z_\-\s0-9\.\(\)]+)+):(?:line|Zeile)? (\d+)", RegexOptions.IgnoreCase);
+        private readonly StackTraceEditor _textEditor;
+        public static readonly Regex FilePathRegex = new Regex(@"((?:[A-Za-z]\:|\\|/)(?:[\\/a-zA-Z_\-\s0-9\.\(\)]+)+):(?:line|Zeile)? (\d+)", RegexOptions.IgnoreCase);
 
-        public FileLinkElementGenerator(TextEditor textEditor)
+        public FileLinkElementGenerator(StackTraceEditor textEditor)
         {
             _textEditor = textEditor;
         }
@@ -52,17 +52,10 @@ namespace StackTraceExplorer.Generators
                 return null;
             }
 
-            var localFilePath = ClickHelper.Find(match.Groups[1].Value).Result;
-
-            if (!File.Exists(localFilePath))
-            {
-                return null;
-            }
-
             var line = new CustomLinkVisualLineText(
-                new [] { match.Groups[1].Value, match.Groups[2].Value }, 
-                CurrentContext.VisualLine, 
-                match.Groups[0].Length, 
+                new[] { match.Groups[1].Value, match.Groups[2].Value },
+                CurrentContext.VisualLine,
+                match.Groups[0].Length,
                 ToBrush(EnvironmentColors.ControlLinkTextColorKey),
                 ClickHelper.HandleFileLinkClicked,
                 false,

--- a/StackTraceExplorer.Shared/Generators/MemberLinkElementGenerator.cs
+++ b/StackTraceExplorer.Shared/Generators/MemberLinkElementGenerator.cs
@@ -15,8 +15,7 @@ namespace StackTraceExplorer.Generators
         // textEditor.TextArea.TextView.ElementGenerators.Add(new MemberLinkElementGenerator());
 
         private readonly StackTraceEditor _textEditor;
-        //public static readonly Regex MemberRegex = new Regex(@"(?:([A-Za-z0-9]+(?:\.|\(.*?\))))+", RegexOptions.IgnoreCase);
-        public static readonly Regex MemberRegex = new Regex(@"([A-Za-z0-9<>_`]+\.)*([A-Za-z0-9<>_\[\]]+\(.*?\))", RegexOptions.IgnoreCase);
+        public static readonly Regex MemberRegex = new Regex(@"([A-Za-z0-9<>_`]+\.)*((.ctor|[A-Za-z0-9<>_\[,\]])+\(.*?\))", RegexOptions.IgnoreCase);
 
         private string _fullMatchText;
 
@@ -73,7 +72,7 @@ namespace StackTraceExplorer.Generators
 
             // If we have created elements for the entire definition, reset. 
             // So we can create elements for more definitions
-            if (_fullMatchText.Split('.').Last().Equals(captures.First()))
+            if (_fullMatchText.EndsWith(captures.First()))
             {
                 _fullMatchText = null;
             }

--- a/StackTraceExplorer.Shared/Generators/MemberLinkElementGenerator.cs
+++ b/StackTraceExplorer.Shared/Generators/MemberLinkElementGenerator.cs
@@ -14,13 +14,13 @@ namespace StackTraceExplorer.Generators
         // To use this class:
         // textEditor.TextArea.TextView.ElementGenerators.Add(new MemberLinkElementGenerator());
 
-        private readonly TextEditor _textEditor;
+        private readonly StackTraceEditor _textEditor;
         //public static readonly Regex MemberRegex = new Regex(@"(?:([A-Za-z0-9]+(?:\.|\(.*?\))))+", RegexOptions.IgnoreCase);
-        public static readonly Regex MemberRegex = new Regex(@"([A-Za-z0-9<>_]+\.)*([A-Za-z0-9<>_]+\(.*?\))", RegexOptions.IgnoreCase);
+        public static readonly Regex MemberRegex = new Regex(@"([A-Za-z0-9<>_`]+\.)*([A-Za-z0-9<>_\[\]]+\(.*?\))", RegexOptions.IgnoreCase);
 
         private string _fullMatchText;
 
-        public MemberLinkElementGenerator(TextEditor textEditor)
+        public MemberLinkElementGenerator(StackTraceEditor textEditor)
         {
             _textEditor = textEditor;
         }

--- a/StackTraceExplorer.Shared/Helpers/ClickHelper.cs
+++ b/StackTraceExplorer.Shared/Helpers/ClickHelper.cs
@@ -3,6 +3,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 using File = System.IO.File;
 using Path = System.IO.Path;
 
@@ -15,59 +18,82 @@ namespace StackTraceExplorer.Helpers
         /// </summary>
         /// <param name="input">File path</param>
         /// <returns>File found</returns>
-        public static bool HandleFileLinkClicked(string[] input)
+        public static void HandleFileLinkClicked(string[] input, StackTraceEditor stackTraceEditor)
         {
-            try
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                var path = Find(input[0]).Result;
-
-                if (!File.Exists(path))
+                var start = DateTime.UtcNow;
+                OutputWindowPane outputWindow = await stackTraceEditor.EnsureOutputWindowPaneAsync();
+                try
                 {
-                    return true;
+                    var path = await Find(input[0], stackTraceEditor);
+
+                    if (!File.Exists(path))
+                    {
+                        await VS.StatusBar.ShowMessageAsync($"FileLinkClicked: {input[0]}. Unable to resolve path");
+                        await outputWindow.WriteLineAsync($"FileLinkClicked: {input[0]}. Unable to resolve path");
+                        return;
+                    }
+
+                    var documentView = await VS.Documents.OpenAsync(path);
+
+                    ITextSnapshotLine line = documentView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(int.Parse(input[1]) - 1);
+                    documentView?.TextView?.ViewScroller.EnsureSpanVisible(line.Extent);
+                    var selectionBroker = documentView.TextView?.GetMultiSelectionBroker();
+                    if (selectionBroker != null)
+                    {
+                        selectionBroker.SetSelection(new Microsoft.VisualStudio.Text.Selection(line.Extent));
+                    }
+
+                    await outputWindow.WriteLineAsync($"FileLinkClicked: {input[0]} finished in {DateTime.UtcNow.Subtract(start)}");
                 }
-
-                var documentView = VS.Documents.OpenAsync(path).Result;
-
-                var line = documentView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(int.Parse(input[1]));
-                documentView?.TextView?.ViewScroller.EnsureSpanVisible(line.Extent);
-
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+                catch (Exception e)
+                {
+                    await outputWindow.WriteLineAsync($"FileLinkClicked: {input[0]} error:\r\n{e}");
+                }
+            });
         }
 
         /// <summary>
         /// Handle click event on a member in a stacktrace
         /// </summary>
         /// <param name="input">Function name</param>
-        /// <returns>Function found</returns>
-        public static bool HandleMemberLinkClicked(string[] input)
+        public static void HandleMemberLinkClicked(string[] input, StackTraceEditor stackTraceEditor)
         {
-            try
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                var member = SolutionHelper.Resolve(GetInput(input));
-
-                if (member == null)
+                var start = DateTime.UtcNow;
+                string typeOrMemberName = GetTypeOrMemberName(input);
+                OutputWindowPane outputWindow = await stackTraceEditor.EnsureOutputWindowPaneAsync();
+                try
                 {
-                    return false;
+                    var member = SolutionHelper.Resolve(typeOrMemberName);
+
+                    if (member == null)
+                    {
+                        await outputWindow.WriteLineAsync($"MemberLinkClicked: {typeOrMemberName} unable to resolve name.");
+                        return;
+                    }
+
+                    var location = member.Locations.FirstOrDefault();
+
+                    var documentView = await VS.Documents.OpenAsync(location.SourceTree.FilePath);
+                    var line = documentView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(location.GetLineSpan().StartLinePosition.Line);
+                    documentView?.TextView?.ViewScroller.EnsureSpanVisible(line.Extent);
+                    var selectionBroker = documentView.TextView?.GetMultiSelectionBroker();
+                    if (selectionBroker != null)
+                    {
+                        var snapshotSpan = new SnapshotSpan(documentView.TextView.TextSnapshot, location.SourceSpan.Start, location.SourceSpan.Length);
+                        selectionBroker.SetSelection(new Microsoft.VisualStudio.Text.Selection(snapshotSpan));
+                    }
+
+                    await outputWindow.WriteLineAsync($"MemberLinkClicked: {typeOrMemberName} finished in {DateTime.UtcNow.Subtract(start)}");
                 }
-
-                var location = member.Locations.FirstOrDefault();
-
-                var documentView = VS.Documents.OpenAsync(location.SourceTree.FilePath).Result;
-
-                var line = documentView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(location.GetLineSpan().StartLinePosition.Line + 1);
-                documentView?.TextView?.ViewScroller.EnsureSpanVisible(line.Extent);
-
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+                catch (Exception e)
+                {
+                    await outputWindow.WriteLineAsync($"MemberLinkClicked: {typeOrMemberName} error:\r\n{e}");
+                }
+            });
         }
 
         /// <summary>
@@ -76,49 +102,65 @@ namespace StackTraceExplorer.Helpers
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
-        public static async Task<string> Find(string path)
+        public static async Task<string> Find(string path, StackTraceEditor stackTraceEditor)
         {
-            if (string.IsNullOrEmpty(path))
+            var outputWindow = await stackTraceEditor.EnsureOutputWindowPaneAsync();
+            DateTime start = DateTime.UtcNow;
+            try
             {
-                return string.Empty;
-            }
+                if (string.IsNullOrEmpty(path))
+                {
+                    await outputWindow.WriteLineAsync($"FindFile: '{path}' is null or empty");
+                    return string.Empty;
+                }
 
-            if (File.Exists(path))
-            {
-                return path;
-            }
+                if (File.Exists(path))
+                {
+                    await outputWindow.WriteLineAsync($"FindFile: '{path}' File Exists");
+                    return path;
+                }
 
-            var pathParts = path.Split(new char[] { Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar },
-                StringSplitOptions.RemoveEmptyEntries);
+                string fileNameOnly = Path.GetFileName(path);
 
-            var solution = await VS.Solutions.GetCurrentSolutionAsync();
+                var solution = await VS.Solutions.GetCurrentSolutionAsync();
+                if (solution == null)
+                {
+                    return string.Empty;
+                }
 
-            if (solution == null)
-            {
-                return string.Empty;
-            }
-
-            var solutionDir = new DirectoryInfo(Path.GetDirectoryName(solution.FullPath));
-
-            for (var i = 0; i < pathParts.Length; i++)
-            {
-                var partialPath = string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.Skip(i));
-
+                var solutionDir = new DirectoryInfo(Path.GetDirectoryName(solution.FullPath));
                 try
                 {
-                    var file = solutionDir.GetFiles($"{partialPath}*", SearchOption.AllDirectories).FirstOrDefault();
+                    await outputWindow.WriteLineAsync($"FindFile: '{path}' looking for '{fileNameOnly}' in '{solutionDir.FullName}'");
+                    FileInfo[] fileInfos = solutionDir.GetFiles($"{fileNameOnly}", SearchOption.AllDirectories);
+                    string[] files = fileInfos.Select(fi => fi.FullName).ToArray();
+                    await outputWindow.WriteLineAsync($"FindFile: '{path}' found {files.Length} potential matches");
+                    if (files.Length == 0)
+                    {
+                        return string.Empty;
+                    }
+
+                    string file = StringHelper.FindLongestMatchingSuffix(path, files, StringComparison.OrdinalIgnoreCase);
 
                     if (file != null)
                     {
-                        return file.FullName;
+                        await outputWindow.WriteLineAsync($"FindFile: '{path}' returning file: '{file}'");
+                        return file;
                     }
                 }
-                catch
+                catch (Exception e)
                 {
+                    await outputWindow.WriteLineAsync($"FindFile: '{path}' error:\r\n{e}");
                 }
-            }
 
-            return path;
+                await outputWindow.WriteLineAsync($"FindFile: '{path}' returning original path! Is this bad?'");
+                return path;
+            }
+            finally
+            {
+                var elapsed = DateTime.UtcNow - start;
+                await outputWindow.WriteLineAsync($"FindFile: '{path}' completed in {elapsed}");
+            }
         }
 
         /// <summary>
@@ -126,7 +168,7 @@ namespace StackTraceExplorer.Helpers
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
-        public static string GetInput(string[] input)
+        public static string GetTypeOrMemberName(string[] input)
         {
             var needle = input[1].TrimEnd('.');
             var index = input[0].IndexOf(needle);

--- a/StackTraceExplorer.Shared/Helpers/ClickHelper.cs
+++ b/StackTraceExplorer.Shared/Helpers/ClickHelper.cs
@@ -20,7 +20,7 @@ namespace StackTraceExplorer.Helpers
         /// <returns>File found</returns>
         public static void HandleFileLinkClicked(string[] input, StackTraceEditor stackTraceEditor)
         {
-            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 var start = DateTime.UtcNow;
                 OutputWindowPane outputWindow = await stackTraceEditor.EnsureOutputWindowPaneAsync();
@@ -30,8 +30,9 @@ namespace StackTraceExplorer.Helpers
 
                     if (!File.Exists(path))
                     {
-                        await VS.StatusBar.ShowMessageAsync($"FileLinkClicked: {input[0]}. Unable to resolve path");
-                        await outputWindow.WriteLineAsync($"FileLinkClicked: {input[0]}. Unable to resolve path");
+                        string message = $"FileLinkClicked: {input[0]}: Unable to resolve file.";
+                        await VS.StatusBar.ShowMessageAsync(message);
+                        await outputWindow.WriteLineAsync(message);
                         return;
                     }
 
@@ -60,7 +61,7 @@ namespace StackTraceExplorer.Helpers
         /// <param name="input">Function name</param>
         public static void HandleMemberLinkClicked(string[] input, StackTraceEditor stackTraceEditor)
         {
-            _ = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 var start = DateTime.UtcNow;
                 string typeOrMemberName = GetTypeOrMemberName(input);
@@ -71,7 +72,9 @@ namespace StackTraceExplorer.Helpers
 
                     if (member == null)
                     {
-                        await outputWindow.WriteLineAsync($"MemberLinkClicked: {typeOrMemberName} unable to resolve name.");
+                        string message = $"MemberLinkClicked: {typeOrMemberName}: unable to resolve member.";
+                        await VS.StatusBar.ShowMessageAsync(message);
+                        await outputWindow.WriteLineAsync(message);
                         return;
                     }
 

--- a/StackTraceExplorer.Shared/Helpers/StringHelper.cs
+++ b/StackTraceExplorer.Shared/Helpers/StringHelper.cs
@@ -1,0 +1,44 @@
+﻿namespace StackTraceExplorer.Helpers
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    public static class StringHelper
+    {
+        public static string FindLongestMatchingSuffix(string searchString, string[] candidates, StringComparison comparisonType)
+        {
+            int nextSeparatorIndex = 0;
+            int previousSeparatorIndex = -1;
+            while (true)
+            {
+                string suffixToSearchFor;
+                if (previousSeparatorIndex == -1)
+                {
+                    // Search for the whole string the first time
+                    suffixToSearchFor = searchString;
+                }
+                else
+                {
+                    nextSeparatorIndex = searchString.IndexOf(Path.DirectorySeparatorChar.ToString(), previousSeparatorIndex);
+                    if (nextSeparatorIndex == -1)
+                    {
+                        break;
+                    }
+
+                    suffixToSearchFor = searchString.Substring(nextSeparatorIndex);
+                }
+
+                string match = candidates.FirstOrDefault(s => s.EndsWith(suffixToSearchFor, comparisonType));
+                if (match != null)
+                {
+                    return match;
+                }
+
+                previousSeparatorIndex = nextSeparatorIndex + 1;
+            }
+
+            throw new ArgumentException("None of the candidates match", nameof(candidates));
+        }
+    }
+}

--- a/StackTraceExplorer.Shared/StackTraceEditor.cs
+++ b/StackTraceExplorer.Shared/StackTraceEditor.cs
@@ -1,14 +1,29 @@
-﻿using ICSharpCode.AvalonEdit;
+﻿using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using ICSharpCode.AvalonEdit;
 using StackTraceExplorer.Generators;
 
 namespace StackTraceExplorer
 {
     public class StackTraceEditor : TextEditor
     {
+        OutputWindowPane outputWindowPane;
+
         public StackTraceEditor()
         {
             TextArea.TextView.ElementGenerators.Add(new FileLinkElementGenerator(this));
             TextArea.TextView.ElementGenerators.Add(new MemberLinkElementGenerator(this));
+        }
+
+        public async Task<OutputWindowPane> EnsureOutputWindowPaneAsync()
+        {
+            const string OutputWindowName = nameof(StackTraceExplorer);
+            if (this.outputWindowPane == null)
+            {
+                this.outputWindowPane = await VS.Windows.CreateOutputWindowPaneAsync(OutputWindowName);
+            }
+
+            return this.outputWindowPane;
         }
     }
 }

--- a/StackTraceExplorer.Shared/StackTraceExplorer.Shared.projitems
+++ b/StackTraceExplorer.Shared/StackTraceExplorer.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Generators\MemberLinkElementGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ClickHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\SolutionHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\StringHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\TraceHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\StackTracesViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StackTraceEditor.cs" />

--- a/StackTraceExplorer.Shared/StackTraceExplorerToolWindowControl.xaml.cs
+++ b/StackTraceExplorer.Shared/StackTraceExplorerToolWindowControl.xaml.cs
@@ -90,9 +90,11 @@ namespace StackTraceExplorer
                 return;
             }
 
+            int selectionStart = textEditor.SelectionStart;
             textEditor.TextChanged -= TextEditor_TextChanged;
             ViewModel.SetStackTrace(trace);
             textEditor.TextChanged += TextEditor_TextChanged;
+            textEditor.SelectionStart = selectionStart;
 
             var workspace = TraceHelper.ComponentModel.GetService<VisualStudioWorkspace>();
             SolutionHelper.Solution = workspace.CurrentSolution;

--- a/StackTraceExplorer.Tests/FileRegexTests.cs
+++ b/StackTraceExplorer.Tests/FileRegexTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StackTraceExplorer.Generators;
+
+namespace StackTraceExplorer.Tests
+{
+    [TestClass]
+    public class FileRegexTests
+    {
+        [DataTestMethod]
+        [DataRow(
+            @"at Bla.Program.InnerClass.InnerMain() in C:\repos\Bla.Program\InnerClass.cs:line 168",
+            @"C:\repos\Bla.Program\InnerClass.cs:line 168",
+            @"C:\repos\Bla.Program\InnerClass.cs",
+            "168")]
+        [DataRow(
+            @"at Bla.Program.InnerClass.InnerMain() in D:\repos\Bla.Program\Dash-File.cs:line 3005",
+            @"D:\repos\Bla.Program\Dash-File.cs:line 3005",
+            @"D:\repos\Bla.Program\Dash-File.cs",
+            "3005")]
+        [DataRow(
+            @"at Bla.Program.InnerClass.InnerMain() in C:\repos\Bla.Program\Dot.File.cs:line 3",
+            @"C:\repos\Bla.Program\Dot.File.cs:line 3",
+            @"C:\repos\Bla.Program\Dot.File.cs",
+            "3")]
+        [DataRow(
+            @"at Program.ApplicationMdi.<Button_Click>b__59_0() in E:\Repos\Underscore_File.cs:line 375",
+            @"E:\Repos\Underscore_File.cs:line 375",
+            @"E:\Repos\Underscore_File.cs",
+            "375")]
+        public void ShouldMatch(string input, string expectedMatch, string expectedFile, string expectedLine)
+        {
+            var match = FileLinkElementGenerator.FilePathRegex.Match(input);
+
+            Assert.IsTrue(match.Success, "Match was not a success!");
+            Assert.AreEqual(expectedMatch, match.Value, nameof(expectedMatch));
+
+            var captures = match.Groups[1].Captures.Cast<Capture>().Select(c => c.Value).ToArray();
+            Assert.AreEqual(1, captures.Length, "captures.Length did not match expected");
+            Assert.AreEqual(expectedFile, captures[0], nameof(expectedFile));
+
+            Assert.AreEqual(expectedLine, match.Groups[2].Value, nameof(expectedLine));
+        }
+    }
+}

--- a/StackTraceExplorer.Tests/LongestSuffixTests.cs
+++ b/StackTraceExplorer.Tests/LongestSuffixTests.cs
@@ -1,0 +1,44 @@
+﻿namespace StackTraceExplorer.Tests
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using StackTraceExplorer.Helpers;
+
+    [TestClass]
+    public class LongestSuffixTests
+    {
+        [DataTestMethod]
+        [DataRow(
+            @"D:\bldserver01\src\product\Project1\Sample.cs",
+            new[] { @"C:\Sample.cs", @"C:\src\Project1\Sample.cs", @"D:\src\product\Project1\Sample.cs" },
+            @"D:\src\product\Project1\Sample.cs")]
+        [DataRow(
+            @"D:\bldserver01\src\product\Project1\Sample.cs",
+            new[] { @"C:\Sample.cs", @"C:\src\Project1\Sample.cs", @"C:\product\Project1\Sample.cs" },
+            @"C:\product\Project1\Sample.cs")]
+        [DataRow(
+            @"D:\test\product\Project1\Sample.cs",
+            new[] { @"C:\test\product\Project1\Sample.cs", @"D:\test\product\Project1\Sample.cs" },
+            @"D:\test\product\Project1\Sample.cs")]
+        public void LongestSuffixMatch(string path, string[] candidates, string expected)
+        {
+            string longestMatched = StringHelper.FindLongestMatchingSuffix(path, candidates, StringComparison.OrdinalIgnoreCase);
+            Assert.AreEqual(expected, longestMatched);
+        }
+
+        [DataTestMethod]
+        [DataRow(
+            @"D:\src\Project1\DifferentFileName.cs",
+            new[] { @"C:\DifferentFileName2.cs", @"C:\src\Project1\DifferentFileName2.cs", },
+            "None of the candidates match")]
+        [DataRow(
+            @"C:\CandidateFileNameMatchingWithSuffix.cs",
+            new[] { @"C:\OtherCandidateFileNameMatchingWithSuffix.cs", },
+            "None of the candidates match")]
+        public void LongestSuffixMatchNoMatches(string path, string[] candidates, string exceptionText)
+        {
+            var exception = Assert.ThrowsException<ArgumentException>(() => StringHelper.FindLongestMatchingSuffix(path, candidates, StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(exception.Message.Contains(exceptionText), $"Exception.Message should contain '{exceptionText}' (actual:{exception.Message})");
+        }
+    }
+}

--- a/StackTraceExplorer.Tests/MemberRegexTests.cs
+++ b/StackTraceExplorer.Tests/MemberRegexTests.cs
@@ -40,6 +40,25 @@ namespace StackTraceExplorer.Tests
             "Company.SomeType`1.StepCallback(IAsyncResult result)",
             new[] { "Company.", "SomeType`1." },
             "StepCallback(IAsyncResult result)")]
+        [DataRow(
+            @" at StackTraceExplorer.TestClass.End[T,V](String s) in D:\StackTraceExplorer\TestClass.cs:line 38",
+            "StackTraceExplorer.TestClass.End[T,V](String s)",
+            new[] { "StackTraceExplorer.", "TestClass." },
+            "End[T,V](String s)")]
+        [DataRow(
+            "  at SolutionHelperTests.ClassWithGenericTypeArgs`2.StaticMethod[V]()",
+            "SolutionHelperTests.ClassWithGenericTypeArgs`2.StaticMethod[V]()",
+            new[] { "SolutionHelperTests.", "ClassWithGenericTypeArgs`2.", },
+            "StaticMethod[V]()")]
+        [DataRow(
+            "  at StackTraceExplorer.Tests.SolutionHelperTests.<>c.<CreateSomeStackTraces>b__6_3() in D:\\SolutionHelperTests.cs:line 52",
+            "StackTraceExplorer.Tests.SolutionHelperTests.<>c.<CreateSomeStackTraces>b__6_3()",
+            new[] { "StackTraceExplorer.", "Tests.", "SolutionHelperTests.", "<>c." },
+            "<CreateSomeStackTraces>b__6_3()")]
+        [DataRow("at Sample.ClassWithGenericTypeArgs`1..ctor(Boolean throwException)",
+            "Sample.ClassWithGenericTypeArgs`1..ctor(Boolean throwException)",
+            new[] { "Sample.", "ClassWithGenericTypeArgs`1.", },
+            ".ctor(Boolean throwException)")]
         public void ShouldMatch(string input, string expectedMatch, string[] expectedCaptures, string expectedMethod)
         {
             var match = MemberLinkElementGenerator.MemberRegex.Match(input);
@@ -55,6 +74,16 @@ namespace StackTraceExplorer.Tests
             }
 
             Assert.AreEqual(expectedMethod, match.Groups[2].Value, nameof(expectedMethod));
+        }
+
+        [DataTestMethod]
+        [DataRow("whatever[0]")]
+        [DataRow("Normal sentence (pretty much)")]
+        [DataRow("Normal sentence [pretty much]")]
+        public void ShouldNotMatch(string input)
+        {
+            var match = MemberLinkElementGenerator.MemberRegex.Match(input);
+            Assert.IsFalse(match.Success, $"Input {input} should not match.");
         }
     }
 }

--- a/StackTraceExplorer.Tests/MemberRegexTests.cs
+++ b/StackTraceExplorer.Tests/MemberRegexTests.cs
@@ -1,32 +1,60 @@
-﻿using NUnit.Framework;
-using StackTraceExplorer.Generators;
-using System.Linq;
+﻿using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StackTraceExplorer.Generators;
 
 namespace StackTraceExplorer.Tests
 {
-    [TestFixture]
+    [TestClass]
     public class MemberRegexTests
     {
-        [TestCase("Bla.Program.Main(String[] args)", 
-            "Bla.Program.Main(String[] args)", new string[]{ "Bla.", "Program." }, "Main(String[] args)")]
-        [TestCase(@"at Bla.Program.InnerClass.InnerMain() in C:\repos\Bla.Program\InnerClass.cs:line 168",
-            "Bla.Program.InnerClass.InnerMain()", new string[] { "Bla.", "Program.", "InnerClass." }, "InnerMain()")]
-        [TestCase(@"at Bla.Program.ApplicationMdi.<Button_Click>b__59_0() in C:\Repos\Bla.Program\Views\ApplicationMdi.cs:line 375",
-            "Bla.Program.ApplicationMdi.<Button_Click>b__59_0()", new string[] { "Bla.", "Program.", "ApplicationMdi." }, "<Button_Click>b__59_0()")]
-        [TestCase(@"at Bla.Program.ApplicationMdi.<>c.<Button_Click>b__59_0() in C:\Repos\Bla.Program\Views\ApplicationMdi.cs:line 375",
-            "Bla.Program.ApplicationMdi.<>c.<Button_Click>b__59_0()", new string[] { "Bla.", "Program.", "ApplicationMdi.", "<>c." }, "<Button_Click>b__59_0()")]
+        [DataTestMethod]
+        [DataRow("Bla.Program.Main(String[] args)", "Bla.Program.Main(String[] args)", new [] { "Bla.", "Program." }, "Main(String[] args)")]
+        [DataRow(
+            @"at Bla.Program.InnerClass.InnerMain() in C:\repos\Bla.Program\InnerClass.cs:line 168",
+            "Bla.Program.InnerClass.InnerMain()",
+            new [] { "Bla.", "Program.", "InnerClass." },
+            "InnerMain()")]
+        [DataRow(
+            @"at Bla.Program.ApplicationMdi.<Button_Click>b__59_0() in C:\Repos\Bla.Program\Views\ApplicationMdi.cs:line 375",
+            "Bla.Program.ApplicationMdi.<Button_Click>b__59_0()",
+            new [] { "Bla.", "Program.", "ApplicationMdi." },
+            "<Button_Click>b__59_0()")]
+        [DataRow(
+            @"at Bla.Program.ApplicationMdi.<>c.<Button_Click>b__59_0() in C:\Repos\Bla.Program\Views\ApplicationMdi.cs:line 375",
+            "Bla.Program.ApplicationMdi.<>c.<Button_Click>b__59_0()",
+            new [] { "Bla.", "Program.", "ApplicationMdi.", "<>c." },
+            "<Button_Click>b__59_0()")]
+        [DataRow(
+            "at Company.Common.AsyncResult.End(IAsyncResult result)",
+            "Company.Common.AsyncResult.End(IAsyncResult result)",
+            new[] { "Company.", "Common.", "AsyncResult." },
+            "End(IAsyncResult result)")]
+        [DataRow(
+            "at Company.Common.AsyncResult.End[TAsyncResult](IAsyncResult result)",
+            "Company.Common.AsyncResult.End[TAsyncResult](IAsyncResult result)",
+            new[] { "Company.", "Common.", "AsyncResult." },
+            "End[TAsyncResult](IAsyncResult result)")]
+        [DataRow(
+            "Company.SomeType`1.StepCallback(IAsyncResult result)",
+            "Company.SomeType`1.StepCallback(IAsyncResult result)",
+            new[] { "Company.", "SomeType`1." },
+            "StepCallback(IAsyncResult result)")]
         public void ShouldMatch(string input, string expectedMatch, string[] expectedCaptures, string expectedMethod)
         {
             var match = MemberLinkElementGenerator.MemberRegex.Match(input);
 
-            Assert.IsTrue(match.Success);
-            Assert.AreEqual(expectedMatch, match.Value);
+            Assert.IsTrue(match.Success, "Match was not a success!");
+            Assert.AreEqual(expectedMatch, match.Value, nameof(expectedMatch));
 
             var captures = match.Groups[1].Captures.Cast<Capture>().Select(c => c.Value).ToArray();
-            Assert.AreEqual(expectedCaptures, captures);
+            Assert.AreEqual(expectedCaptures.Length, captures.Length, "captures.Length did not match expected");
+            for (int i = 0; i < expectedCaptures.Length; i++)
+            {
+                Assert.AreEqual(expectedCaptures[i], captures[i], $"Capture at index {i} did not match");
+            }
 
-            Assert.AreEqual(expectedMethod, match.Groups[2].Value);
+            Assert.AreEqual(expectedMethod, match.Groups[2].Value, nameof(expectedMethod));
         }
     }
 }

--- a/StackTraceExplorer.Tests/SolutionHelperTests.cs
+++ b/StackTraceExplorer.Tests/SolutionHelperTests.cs
@@ -1,11 +1,24 @@
 ﻿namespace StackTraceExplorer.Tests
 {
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Runtime.CompilerServices;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using StackTraceExplorer.Helpers;
 
     [TestClass]
     public class SolutionHelperTests
     {
+        public SolutionHelperTests()
+        {
+            this.Compilation = CreateCompilationForCurrentFile();
+        }
+
+        CSharpCompilation Compilation { get; }
+
         [DataTestMethod]
         [DataRow("End[TAsyncResult](IAsyncResult result)", "End")]
         [DataRow("Main(String[] args)", "Main")]
@@ -16,6 +29,112 @@
         {
             string memberName = SolutionHelper.GetMemberName(input);
             Assert.AreEqual(expected, memberName);
+        }
+
+        [DataTestMethod]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests")]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests..ctor()")]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests.ResolveMember(String memberName)")]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests.ThisMethodThrows[T](String s)")]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests.ThisMethodThrows[T,V](String s)")]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests.ClassWithGenericTypeArgs`2")]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests.ClassWithGenericTypeArgs`1..ctor(Boolean throwException)")]
+        [DataRow("StackTraceExplorer.Tests.SolutionHelperTests.ClassWithGenericTypeArgs`1.StaticMethod[C]()")]
+        // This Doesn't work
+        // [DataRow("StackTraceExplorer.Tests.SolutionHelperTests.<>c.<CreateSomeStackTraces>b__6_3()")]
+        public void ResolveMember(string memberName)
+        {
+            ISymbol symbol = SolutionHelper.Resolve(this.Compilation, memberName);
+            Assert.IsNotNull(symbol, $"Symbol {memberName} should be found");
+        }
+
+        [TestMethod]
+        public void CreateSomeStackTraces()
+        {
+            Trace.WriteLine(GetExceptionToString(() => ClassWithGenericTypeArgs<string>.StaticMethod<int>()));
+            Trace.WriteLine(GetExceptionToString(() => new ClassWithGenericTypeArgs<string>(throwException: true)));
+            Trace.WriteLine(GetExceptionToString(() => new ClassWithGenericTypeArgs<string>(throwException: false).InstanceMethod<byte>()));
+
+            Trace.WriteLine(GetExceptionToString(() => ClassWithGenericTypeArgs<string, object>.StaticMethod<int>()));
+            Trace.WriteLine(GetExceptionToString(() => new ClassWithGenericTypeArgs<string, string>(throwException: true)));
+            Trace.WriteLine(GetExceptionToString(() => new ClassWithGenericTypeArgs<string, int>(throwException: false).InstanceMethod<int>()));
+        }
+
+        public static CSharpCompilation CreateCompilationForCurrentFile([CallerFilePath] string fileName = "")
+        {
+            var compilation = CSharpCompilation.Create("TempAssembly");
+            string sourceText = File.ReadAllText(fileName);
+            SyntaxTree tree = CSharpSyntaxTree.ParseText(sourceText);
+            compilation = compilation.AddSyntaxTrees(tree);
+            return compilation;
+        }
+
+        public static string GetExceptionToString(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                return e.ToString();
+            }
+
+            return string.Empty;
+        }
+
+        // Used in Test DataRows
+        static void ThisMethodThrows<T>(string s)
+        {
+            throw new NotImplementedException("foo");
+        }
+
+        // Used in Test DataRows
+        static void ThisMethodThrows<T, V>(string s)
+        {
+            throw new NotImplementedException("foo");
+        }
+
+        class ClassWithGenericTypeArgs<A>
+        {
+            public ClassWithGenericTypeArgs(bool throwException)
+            {
+                if (throwException)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public string InstanceMethod<B>()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static string StaticMethod<C>()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class ClassWithGenericTypeArgs<A,B>
+        {
+            public ClassWithGenericTypeArgs(bool throwException)
+            {
+                if (throwException)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public string InstanceMethod<C>()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static string StaticMethod<D>()
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/StackTraceExplorer.Tests/SolutionHelperTests.cs
+++ b/StackTraceExplorer.Tests/SolutionHelperTests.cs
@@ -1,0 +1,21 @@
+﻿namespace StackTraceExplorer.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using StackTraceExplorer.Helpers;
+
+    [TestClass]
+    public class SolutionHelperTests
+    {
+        [DataTestMethod]
+        [DataRow("End[TAsyncResult](IAsyncResult result)", "End")]
+        [DataRow("Main(String[] args)", "Main")]
+        [DataRow("GenericType`1", "GenericType")]
+        [DataRow("<GetSteps>d__0", "GetSteps")]
+        [DataRow("get_TestProperty()", "get_TestProperty")]
+        public void GetMemberName(string input, string expected)
+        {
+            string memberName = SolutionHelper.GetMemberName(input);
+            Assert.AreEqual(expected, memberName);
+        }
+    }
+}

--- a/StackTraceExplorer.Tests/StackTraceExplorer.Tests.csproj
+++ b/StackTraceExplorer.Tests/StackTraceExplorer.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,9 +12,14 @@
     <AssemblyName>StackTraceExplorer.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +39,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -49,7 +61,10 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>StackTraceExplorer.vsct</DependentUpon>
     </Compile>
+    <Compile Include="FileRegexTests.cs" />
     <Compile Include="MemberRegexTests.cs" />
+    <Compile Include="SolutionHelperTests.cs" />
+    <Compile Include="LongestSuffixTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -73,8 +88,11 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
       <Version>2.10.0</Version>
     </PackageReference>
-    <PackageReference Include="NUnit">
-      <Version>3.13.2</Version>
+    <PackageReference Include="MSTest.TestAdapter">
+      <Version>2.2.7</Version>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestFramework">
+      <Version>2.2.7</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -85,5 +103,6 @@
     </Content>
   </ItemGroup>
   <Import Project="..\StackTraceExplorer.Shared\StackTraceExplorer.Shared.projitems" Label="Shared" />
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/StackTraceExplorer.Tests/StackTraceExplorer.Tests.csproj
+++ b/StackTraceExplorer.Tests/StackTraceExplorer.Tests.csproj
@@ -83,7 +83,7 @@
       <Version>17.0.76.257-pre</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>2.10.0</Version>
+      <Version>3.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
       <Version>2.10.0</Version>

--- a/StackTraceExplorer.VS2019/StackTraceExplorer.VS2019.csproj
+++ b/StackTraceExplorer.VS2019/StackTraceExplorer.VS2019.csproj
@@ -121,7 +121,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>2.10.0</Version>
+      <Version>3.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
       <Version>2.10.0</Version>

--- a/StackTraceExplorer.VS2019/StackTraceExplorer.VS2019.csproj
+++ b/StackTraceExplorer.VS2019/StackTraceExplorer.VS2019.csproj
@@ -126,6 +126,9 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
       <Version>2.10.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI">
+      <Version>16.10.230</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.0.3177-preview3</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/StackTraceExplorer.VS2022/StackTraceExplorer.VS2022.csproj
+++ b/StackTraceExplorer.VS2022/StackTraceExplorer.VS2022.csproj
@@ -113,7 +113,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>2.10.0</Version>
+      <Version>3.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
       <Version>2.10.0</Version>


### PR DESCRIPTION
[If you're considering accepting any PRs I came up with these changes that you might want to consider taking some or all of...]

- When searching for files on disk avoid so many exceptions. In order to improve performance with large solutions first search for matching files names (ignoring the rest of the path to begin with) and then figure out which of those matches has the longest matching suffix.
- When opening up a file link or a method link select the line or member in the text view.
- Write some logs to the VS Output window
- Add a bit more support for clicking on Generic Type member names (small regex updates)
- A bit better support for clicking and browsing to enumerator methods, such as `<GetSteps>d__1`.
- Controversial? FileLinkElementGenerator will turn file name matches into links without checking for existence of that file while the syntax highlighting is taking place. The previous behavior was resulting in many, many, file accesses and lookups.
- Add some more unit tests (I couldn't get NUnit to work at all, I personally had to use MSTest. I understand you might not want that and we can discuss.)