### PR TITLE
feat: change button name to not be flummoxed with VS2022 builtin feature

### DIFF
--- a/Resources/StackTraceExplorer.vsct
+++ b/Resources/StackTraceExplorer.vsct
@@ -13,7 +13,7 @@
         <Icon guid="ImageCatalogGuid" id="CallStackWindow" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
-          <ButtonText>Stack Trace Explorer</ButtonText>
+          <ButtonText>Stack Trace Explorer (Ext)</ButtonText>
         </Strings>
       </Button>
     </Buttons>


### PR DESCRIPTION
so that we could easily distinguish the 2 "Stack trace explorers"

![image](https://github.com/user-attachments/assets/1593bd6b-f66d-4f4a-a4a1-2c407b49ef7d)

![image](https://github.com/user-attachments/assets/c5198f00-9308-464a-a5c8-75f508026b56)
