### PR TITLE
Fix and improve stack trace processing

### DIFF
--- a/StackTraceExplorer.Shared/Generators/FileLinkElementGenerator.cs
+++ b/StackTraceExplorer.Shared/Generators/FileLinkElementGenerator.cs
@@ -13,7 +13,7 @@ namespace StackTraceExplorer.Generators
         // textEditor.TextArea.TextView.ElementGenerators.Add(new FileLinkElementGenerator());
 
         private readonly StackTraceEditor _textEditor;
-        public static readonly Regex FilePathRegex = new Regex(@"((?:[A-Za-z]\:|\\|/)(?:[\\/a-zA-Z_\-\s0-9\.\(\)]+)+):(?:line|Zeile|строка)?\s?(\d+)", RegexOptions.IgnoreCase);
+        public static readonly Regex FilePathRegex = new Regex(@"((?:[A-Za-z]\:|\\|/)(?:[\\/a-zA-Z_\-\s0-9\.\(\)]+)+):(?:line|Zeile|строка|ligne)?\s?(\d+)", RegexOptions.IgnoreCase);
 
         public FileLinkElementGenerator(StackTraceEditor textEditor)
         {

--- a/StackTraceExplorer.Shared/Generators/MemberLinkElementGenerator.cs
+++ b/StackTraceExplorer.Shared/Generators/MemberLinkElementGenerator.cs
@@ -14,7 +14,7 @@ namespace StackTraceExplorer.Generators
         // textEditor.TextArea.TextView.ElementGenerators.Add(new MemberLinkElementGenerator());
 
         private readonly StackTraceEditor _textEditor;
-        public static readonly Regex MemberRegex = new Regex(@"([A-Za-z0-9<>_`]+\.)*((.ctor|[A-Za-z0-9<>_\[,\]])+\(.*?\))", RegexOptions.IgnoreCase);
+        public static readonly Regex MemberRegex = new Regex(@"([A-Za-z0-9<>_`+]+\.)*((.ctor|[A-Za-z0-9<>_\[,\]|+])+\(.*?\))", RegexOptions.IgnoreCase);
 
         private string _fullMatchText;
 

--- a/StackTraceExplorer.Shared/Models/StackTrace.cs
+++ b/StackTraceExplorer.Shared/Models/StackTrace.cs
@@ -49,10 +49,12 @@ namespace StackTraceExplorer.Shared.Models
             }
 
             var lines = Regex
-                .Split(trace, @"(?=\s+(at|в)\s+)")
+                .Split(trace, @"(?=\s+(at|в|à)\s+)")
                 .Where(line => !string.IsNullOrEmpty(line))
                 .Where(line => !string.IsNullOrWhiteSpace(line))
-                .Where(line => line != "в");
+                .Where(line => line != "at")
+                .Where(line => line != "в")
+                .Where(line => line != "à");
 
             return string.Join(Environment.NewLine, lines);
         }

--- a/StackTraceExplorer.Tests/MemberRegexTests.cs
+++ b/StackTraceExplorer.Tests/MemberRegexTests.cs
@@ -67,6 +67,14 @@ namespace StackTraceExplorer.Tests
             "StackTraceExplorer.Tests.SolutionHelperTests.ClassWithGenericTypeArgs`1.StaticMethod[C]()",
             new[] { "StackTraceExplorer.", "Tests.", "SolutionHelperTests.", "ClassWithGenericTypeArgs`1." },
             "StaticMethod[C]()")]
+        [DataRow(@"StackTraceExplorer.Tests.SolutionHelperTests.<GetAsync>g__Parse|155_0(IEnumerable`1 lines) in C:\StackTraceExplorer.Tests\DummyFile.cs:line 21",
+            "StackTraceExplorer.Tests.SolutionHelperTests.<GetAsync>g__Parse|155_0(IEnumerable`1 lines)",
+            new[] { "StackTraceExplorer.", "Tests.", "SolutionHelperTests." },
+            "<GetAsync>g__Parse|155_0(IEnumerable`1 lines)")]
+        [DataRow(@"StackTraceExplorer.Tests.SolutionHelperTests.ThreadHelper+<>c__DisplayClass13_0+<<FileAndForget>b__0>d.MoveNext() in C:\StackTraceExplorer.Tests\DummyFile.cs:line 21",
+            "StackTraceExplorer.Tests.SolutionHelperTests.ThreadHelper+<>c__DisplayClass13_0+<<FileAndForget>b__0>d.MoveNext()",
+            new[] { "StackTraceExplorer.", "Tests.", "SolutionHelperTests.", "ThreadHelper+<>c__DisplayClass13_0+<<FileAndForget>b__0>d." },
+            "MoveNext()")]
         public void ShouldMatch(string input, string expectedMatch, string[] expectedCaptures, string expectedMethod)
         {
             var match = MemberLinkElementGenerator.MemberRegex.Match(input);


### PR DESCRIPTION
* Remove multiple "at" added when stack trace is pasted
* Add french support (with "à" and "ligne")
* improve method detection when methods names contains '+' and '|' like in:

```
System.Exception: This is a test
   at GitCommands.GitModule.<GetRemotesAsync>g__ParseRemotes|155_0(IEnumerable`1 lines) in C:\...\gitextensions\GitCommands\Git\GitModule.cs:line 2196

```

and 

```
Microsoft.Azure.WebJobs.Host.FunctionTimeoutException:
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor+<TryHandleTimeoutAsync>d__35.MoveNext (Microsoft.Azure.WebJobs.Host, Version=3.0.41.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35: D:\a\_work\1\s\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:663)

```